### PR TITLE
Used URLComponents instead of directly creating a URL with a string

### DIFF
--- a/KPI-Schedule/Managers/GroupManager.swift
+++ b/KPI-Schedule/Managers/GroupManager.swift
@@ -7,9 +7,16 @@ protocol GroupManagerDelegate {
 struct GroupManager {
     var delegate: GroupManagerDelegate?
     
-    func performRequest(group: String, completion: @escaping(GroupModel) -> ()) {
-        if let groupURL = URL(string: "https://schedule.kpi.ua/api/schedule/groups") {
-            
+    func performRequest(group: String, completion: @escaping (GroupModel) -> ()) {
+        var components = URLComponents(string: "https://schedule.kpi.ua/api/schedule/groups")
+        // Set query parameters if needed
+        let queryItems = [
+            URLQueryItem(name: "param1", value: "value1"),
+            URLQueryItem(name: "param2", value: "value2")
+        ]
+        components?.queryItems = queryItems
+        
+        if let groupURL = components?.url {
             URLSession.shared.dataTask(with: groupURL) { data, response, error in
                 if let error = error {
                     self.delegate?.didFailWithGroup()
@@ -19,7 +26,7 @@ struct GroupManager {
                     if let group = self.parseJSON(data: safeData, group: group) {
                         completion(group)
                     } else {
-                        delegate?.didFailWithGroup()
+                        self.delegate?.didFailWithGroup()
                     }
                 }
             }
@@ -27,7 +34,7 @@ struct GroupManager {
         }
     }
     
-    func parseJSON(data: Data, group: String) -> GroupModel? {
+    private func parseJSON(data: Data, group: String) -> GroupModel? {
         do {
             let decodedData = try JSONDecoder().decode(GroupData.self, from: data)
             for groupa in decodedData.data {
@@ -37,7 +44,7 @@ struct GroupManager {
             }
         } catch {
             DispatchQueue.main.async {
-                delegate?.didFailWithGroup()
+                self.delegate?.didFailWithGroup()
             }
         }
         return nil


### PR DESCRIPTION
Use URLComponents for constructing the URL. It's better to use URLComponents instead of directly creating a URL with a string. This helps handle URL encoding and query parameters more reliably.